### PR TITLE
Fix dependency installation via setup.py

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -2,5 +2,5 @@
     name: prospector
     description: "This hook runs Prospector: https://github.com/landscapeio/prospector"
     entry: prospector
-    language: system
+    language: python
     files: \.py$

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(
-    name='__dummy_package',
-    version='0.0.0',
+    name='pre-commit-hooks-prospector-mirror',
+    version='0.1.0',
     install_requires=['prospector>=0.8.0'],
 )


### PR DESCRIPTION
This hook did not install `prospector` as dependency properly, because
of two reasons:
- invalid name and version
- in `hooks.yaml` `language` set to `system` instead of `python`

This commit fixes both of these issues, resulting in a smooth
installation of `prospector` into a virtualenv when running `pre-commit`.